### PR TITLE
add support for POST (#75)

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -87,7 +87,18 @@ export default class Client {
     this.caches.set(query, cache);
   }
   runQuery(query, variables) {
-    return this.runUri(this.getGraphqlQuery({ query, variables }));
+    if ((this.fetchOptions?.method || '').toUpperCase() === 'POST') {
+      return fetch(this.endpoint, {
+        ...this.fetchOptions,
+        headers: {
+          ...this.fetchOptions?.headers,
+          'content-type': 'application/json'
+        },
+        body: JSON.stringify({ query, variables })
+      }).then(resp => resp.json())
+    } else {
+      return this.runUri(this.getGraphqlQuery({ query, variables }));
+    }
   }
   runUri(uri) {
     return fetch(uri, this.fetchOptions || void 0).then(resp => resp.json());


### PR DESCRIPTION
Resolves #75

The tests seem sort of hard to add a new client to, so I skipped it, but I implemented the actual functionality. Additionally, `https://mylibrary.io/graphql-public` seems down, and I can't get the demo-project to build as it is. This is a pretty simple change, though, and I tested with this code:

```js
import { Client, setDefaultClient } from './dist/index.min.js'

const client = new Client({
  endpoint: 'http://localhost:3000/api',
  fetchOptions: { method: 'POST' }
})

setDefaultClient(client)

const QUERY_TEST = `
{
  hello(name: "David")
}
`

console.log(await client.runQuery(QUERY_TEST, {}))
```

on a POST-only graphql server, I get this:

```js
{ data: { hello: 'Hello David' } }
```
